### PR TITLE
Fix admin panel padding and mobile responsiveness

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@
         color: #334155; /* Slate 700 */
     }
     #employee-portal-container { width: 100%; overflow-x: hidden; }
-    #employee-main-content { max-width: 100vw; padding-left: max(env(safe-area-inset-left), 12px); padding-right: max(env(safe-area-inset-right), 12px); }
+    #employee-main-content { max-width: 100vw; padding-left: env(safe-area-inset-left); padding-right: env(safe-area-inset-right); }
 
     /* --- استایل‌های عمومی -- */
     .card {

--- a/js/main.js
+++ b/js/main.js
@@ -1543,7 +1543,7 @@ function renderEmployeePortal() {
                 <div class="blob" style="bottom:-80px; left:-80px; width:220px; height:220px; background:#F72585"></div>
                 
                 <header style="background:linear-gradient(90deg,#FF6A3D,#F72585)" class="shadow-sm relative z-20">
-                    <div class="w-full py-4 px-3 sm:px-6 lg:px-8 flex justify-between items-center" style="padding-top: env(safe-area-inset-top);">
+                    <div class="w-full py-4 px-0 sm:px-6 lg:px-8 flex justify-between items-center" style="padding-top: env(safe-area-inset-top);">
                         <div class="flex items-center gap-3">
                             <button id="portal-menu-btn" class="inline-flex sm:hidden items-center justify-center p-2 rounded-md bg-white/20 hover:bg-white/30 text-white" title="منو"><i data-lucide="menu" class="w-5 h-5"></i></button>
                             <img src="logo.png" alt="Logo" class="w-8 h-8 rounded-md ring-2 ring-white/30">
@@ -1571,7 +1571,7 @@ function renderEmployeePortal() {
                         </div>
                     </div>
                 </header>
-                <main id="employee-main-content" class="flex-1 p-6 sm:p-10 overflow-y-auto relative z-10"></main>
+                <main id="employee-main-content" class="flex-1 p-0 sm:p-6 lg:p-10 overflow-y-auto relative z-10"></main>
             </div>
         </div>
     `;


### PR DESCRIPTION
Remove unwanted mobile margins from the user portal to ensure content is edge-to-edge.

The user portal previously displayed with unnecessary side margins on mobile, making the content appear smaller compared to the admin panel or modals. This PR adjusts the CSS padding for the main content and header to remove these margins, providing a full-width experience on mobile devices.

---
<a href="https://cursor.com/background-agent?bcId=bc-137eaf6e-514a-4805-bcfa-d3293da088a6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-137eaf6e-514a-4805-bcfa-d3293da088a6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

