### PR TITLE
Fix talent display in admin panel

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -184,7 +184,7 @@ const teamVisualsPalette = [
     { icon: 'pen-tool', color: 'text-indigo-500', bg: 'bg-indigo-100' },
     { icon: 'settings-2', color: 'text-slate-500', bg: 'bg-slate-100' }
 ];
-        const appId = 'hr-nik-prod';
+        const appId = 'nikhr-development';
 const firebaseConfig = {
   apiKey: "AIzaSyCEvMeneEts83kYtqRRl3K_BQ8VnoVlqKA",
   authDomain: "nikhr-development.firebaseapp.com",


### PR DESCRIPTION
Update Firestore `appId` to `nikhr-development` to correctly load employee data.

The previous `appId` (`hr-nik-prod`) did not match the configured Firebase project (`nikhr-development`), preventing Firestore collections (e.g., `employees`) from loading. This caused the "talents" section in the admin panel to appear empty.

---
<a href="https://cursor.com/background-agent?bcId=bc-081ba005-58a3-4ea5-9d7f-e180ad3d4eab">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-081ba005-58a3-4ea5-9d7f-e180ad3d4eab">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

